### PR TITLE
Remove .env file and add sample

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,1 +1,0 @@
-FRONTEND_URL="http://localhost:7777"

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,0 +1,2 @@
+FRONTEND_URL="http://localhost:7777"
+DATABASE_URL="postgres://username@localhost/databaseName"

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .keystone/admin
 *.log
+.env

--- a/backend/keystone.ts
+++ b/backend/keystone.ts
@@ -37,8 +37,7 @@ export default auth.withAuth(
     server: {
       cors: {
         // @ts-ignore
-        origin: [process.env.FRONTEND_URL],
-        port: 3000,
+        origin: [process.env.FRONTEND_URL || 'http://localhost:7777'],
         credentials: true,
       },
     },


### PR DESCRIPTION
For project setup, users should supply their own config with .env to set
the correct database URL and not conflict with the URL created at
project start. The .env should also be ignored by git since it contains
system-specific details.

Fixes #2 