### PR TITLE
Fix failed login redirect bug, add type check cmds

### DIFF
--- a/cypress/cypress/integration/login/login.feature
+++ b/cypress/cypress/integration/login/login.feature
@@ -1,7 +1,7 @@
 Feature: Sign Up for New Account
 
         @creates_user
-        Scenario: Filled form successfully registers user
+        Scenario: Existing user can successfully log in and gets redirected to homepage
             Given I am not logged in
               And I have created a user with the following fields:
                   | name          | username    | email                   | password |
@@ -17,3 +17,17 @@ Feature: Sign Up for New Account
              When I click the "Login" button
              Then I see the URL is now "/"
               And I see the text "Welcome, Cypress Test2!"
+
+        Scenario: Failed login does not redirect to home page
+            Given I am not logged in
+              And I navigate to the homepage
+              And I click the "Login" link
+              And I see the URL is now "/login"
+              And I see a header with the text "Login"
+              And I see a "Username" field
+              And I see a "Password" field
+              And I type "DOESNOT3XIST" into the "Username" field
+              And I type "password" into the "Password" field
+             When I click the "Login" button
+             Then I see the URL is now "/login"
+              And I see the text "An error occurred."

--- a/frontend/components/Login.tsx
+++ b/frontend/components/Login.tsx
@@ -66,11 +66,16 @@ export default function Login() {
     password: '',
   });
 
-  const [login, { data, error }] = useMutation(LOGIN_MUTATION, {
+  const [login, { data }] = useMutation(LOGIN_MUTATION, {
     variables: inputs,
     refetchQueries: [{ query: CURRENT_USER_QUERY }],
   });
 
+  const error =
+    data?.authenticateUserWithPassword.__typename ===
+    'UserAuthenticationWithPasswordFailure'
+      ? data?.authenticateUserWithPassword
+      : undefined;
   return (
     <CardStyles>
       <Card style={{ width: '600px' }}>
@@ -80,11 +85,10 @@ export default function Login() {
         <FormStyles
           onSubmit={async (e) => {
             e.preventDefault();
-            try {
-              await login();
-              console.log(data);
+            const result = await login();
+            if (!result?.data?.authenticateUserWithPassword?.message) {
               router.push('/');
-            } catch {}
+            }
           }}
         >
           {error && <Message severity="error" text="An error occurred." />}

--- a/frontend/components/SignUp.tsx
+++ b/frontend/components/SignUp.tsx
@@ -89,10 +89,8 @@ export default function SignUp() {
         <FormStyles
           onSubmit={async (e) => {
             e.preventDefault();
-            try {
-              await signUp();
-              clearForm();
-            } catch {}
+            await signUp();
+            clearForm();
           }}
         >
           {error && (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next -p 7777",
     "build": "next build",
-    "start": "next start -p 7777"
+    "start": "next start -p 7777",
+    "types:check": "tsc --noEmit",
+    "types:watch": "tsc --noEmit --watch"
   },
   "dependencies": {
     "@apollo/client": "^3.3.19",


### PR DESCRIPTION
The onSubmit for the Login form would always redirect even if there was
a failure. Added a small error check on the response of the login
mutation before redirecting.

Fixes #1 